### PR TITLE
Use default InstanceMonitoring (on).

### DIFF
--- a/src/flyingcircus/service/autoscaling.py
+++ b/src/flyingcircus/service/autoscaling.py
@@ -27,7 +27,7 @@ def autoscaling_group_by_cpu(low=20, high=80):
         Properties=dict(
             ImageId="ami-1a668878",  # Amazon Linux 2017.09.01 in ap-southeast-2
             InstanceType="t2.micro",  # TODO consider making this a lookup value
-            InstanceMonitoring=False,  # Disable the costly version of monitoring
+            #TODO KeyName would probably be helpful
         ),
     )
     stack.Resources["LaunchConfiguration"] = launch_config

--- a/tests/service_test/autoscaling_test.py
+++ b/tests/service_test/autoscaling_test.py
@@ -62,7 +62,6 @@ class TestCpuAutoScalingGroup:
             Type: AWS::AutoScaling::LaunchConfiguration
             Properties:
               ImageId: ami-1a668878
-              InstanceMonitoring: false
               InstanceType: t2.micro
           ScaleDownPolicy:
             Type: AWS::AutoScaling::ScalingPolicy


### PR DESCRIPTION
Low usage seems to be in the free tier, so cost concerns are not relevant.