### PR TITLE
#19: You can't specify a variable in the pipeline YAML if you want

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,10 +16,14 @@ variables:
   # Manually set flag for whether to release this build to PyPI (if other
   # preconditions are also met).
   #
+  # In order to do a release, this variable must be defined and set on a
+  # manually queued job
+  #
   # Note that this is evaluated by the Pipelines condition as a truthy string,
   # so False is set as the empty string, and almost anything else evaluates
   # as True.
-  do_release: '' # False
+  #do_release: '' # False
+
   # The name of the library as a pip requirement
   library_name: 'flying-circus'
   # The name of a "Service Connection" in the "Settings" section of the


### PR DESCRIPTION
You can't specify a variable in the pipeline YAML if you want it to be manually set at queue time.

https://docs.microsoft.com/en-us/azure/devops/pipelines/process/variables?view=azure-devops&tabs=yaml%2Cbatch#allow-at-queue-time