### PR TITLE
docs: Fix simple typo, `betwen` -> `between`

### DIFF
--- a/oldsrc/fcspike/core.py
+++ b/oldsrc/fcspike/core.py
@@ -33,7 +33,7 @@ class AWSObject(object):
         for key, value in kwargs.items():
             self.add(key, value)
 
-    # TODO Name. distinguish betwen logical name (for the stack) and physical name (for the created resource). store logical name on the object.
+    # TODO Name. distinguish between logical name (for the stack) and physical name (for the created resource). store logical name on the object.
     # TODO add?
     # TODO canonicalise
     # TODO dict-like interface to set/get fields


### PR DESCRIPTION
Maybe you would prefer to simply remove the oldsrc folder?