### PR TITLE
 doco: Fix simple typo `mroe` -> `more`

### DIFF
--- a/src/flyingcircus/service/autoscaling.py
+++ b/src/flyingcircus/service/autoscaling.py
@@ -83,7 +83,7 @@ def simple_scaling_policy(alarm, asg_name, downscale=False):
 
     alarm.Properties.AlarmActions.append(Fn.Ref(scaling_policy))
     alarm.Properties.Dimensions.append(
-        # TODO logical class that wraps this up instead, and allows you to express in a mroe convenient way
+        # TODO logical class that wraps this up instead, and allows you to express in a more convenient way
         dict(Name="AutoScalingGroupName", Value=asg_name)
     )
     stack.Resources["ScalingAlarm"] = alarm

--- a/src/flyingcircus/service/ssm.py
+++ b/src/flyingcircus/service/ssm.py
@@ -12,6 +12,6 @@ from .._raw.ssm import *
 
 # Also provide an alias for the SSM Parameter resource, to reduce conflicts
 # with the top-level template Parameter object
-# FIXME do these as imports instead, so that pycharm type chekcing picks them up more reliably
+# FIXME do these as imports instead, so that pycharm type checking picks them up more reliably
 SSMParameter = _raw.Parameter
 SSMParameterProperties = _raw.ParameterProperties


### PR DESCRIPTION
Typo Tuesday